### PR TITLE
Only update Christmas and Halloween if the configuration for them is set to true.

### DIFF
--- a/FargoWorld.cs
+++ b/FargoWorld.cs
@@ -184,8 +184,10 @@ namespace Fargowiltas
         public override void PostUpdateWorld()
         {
             // seasonals
-            Main.halloween = GetInstance<FargoConfig>().Halloween;
-            Main.xMas = GetInstance<FargoConfig>().Christmas;
+            if (GetInstance<FargoConfig>().Halloween)
+                Main.halloween = true;
+            if (GetInstance<FargoConfig>().Christmas)
+                Main.xMas = true;
             //seeds
             Main.drunkWorld = GetInstance<FargoConfig>().DrunkWorld;
             Main.notTheBeesWorld = GetInstance<FargoConfig>().BeeWorld;


### PR DESCRIPTION
Terraria ends holidays at the start of a new day by default (except when it's that time of the year in real life), so it isn't necessary to turn off the holidays and it makes it less mod compatible. Some mods may want to activate Christmas or Halloween at a certain time or with an item, but this mod will shut it off right after it does. I think ending the holiday every `PostWorldUpdate()` would also cancel the vanilla mechanic of starting a Holiday after beating the Pumpkin Moon or Frost Moon.